### PR TITLE
Add Laravel 12 and PHP 8.4 support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -11,16 +11,16 @@ jobs:
     name: phpstan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.2'
           coverage: none
 
       - name: Install composer dependencies
-        uses: ramsey/composer-install@v1
+        uses: ramsey/composer-install@v2
 
       - name: Run PHPStan
         run: ./vendor/bin/phpstan analyze -c phpstan.neon.dist --error-format=github

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -2,6 +2,9 @@ name: Fix PHP code style issues
 
 on: [push]
 
+permissions:
+  contents: write
+
 jobs:
   php-code-styling:
     runs-on: ubuntu-latest

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -8,14 +8,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@1.0.0
+        uses: aglipanci/laravel-pint-action@2.5
 
       - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: Fix styling

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,18 +13,15 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1, 8.2]
-        phpunit: [^8.5.23, 9.*, 10.*]
+        php: [8.2, 8.3, 8.4]
+        phpunit: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
-        exclude:
-          - php: 8.0
-            phpunit: 10.*
 
     name: P${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "symfony/dom-crawler": "^6.1|^7.0"
     },
     "require-dev": {
-        "laravel/pint": "^1.0",
+        "laravel/pint": "^1.18",
         "phpstan/phpstan": "^1.8"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,11 +25,11 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
-        "illuminate/macroable": "^7.0|^8.0|^9.0|^10.0|^11.0",
-        "phpunit/phpunit": "^8.3|^9.0|^10.0",
-        "spatie/url": "^1.3.4|^2.0",
-        "symfony/dom-crawler": "^5.4|^6.1"
+        "php": "^8.2",
+        "illuminate/macroable": "^11.0|^12.0",
+        "phpunit/phpunit": "^10.0|^11.0",
+        "spatie/url": "^2.0",
+        "symfony/dom-crawler": "^6.1|^7.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,26 +1,2 @@
 parameters:
-	ignoreErrors:
-		-
-			message: "#^Method Raiolanetworks\\\\PluginSEOTest\\\\SEOData\\:\\:charset\\(\\) should return string\\|null but returns array\\<string, string\\|null\\>\\|string\\|null\\.$#"
-			count: 1
-			path: src/SEOData.php
-
-		-
-			message: "#^Method Raiolanetworks\\\\PluginSEOTest\\\\SEOData\\:\\:description\\(\\) should return string\\|null but returns array\\<string, string\\|null\\>\\|string\\|null\\.$#"
-			count: 1
-			path: src/SEOData.php
-
-		-
-			message: "#^Parameter \\#1 \\$content of class Raiolanetworks\\\\PluginSEOTest\\\\Tags\\\\Robots constructor expects string, array\\<string, string\\|null\\>\\|string given\\.$#"
-			count: 1
-			path: src/SEOData.php
-
-		-
-			message: "#^Parameter \\#1 \\$url of static method Spatie\\\\Url\\\\Url\\:\\:fromString\\(\\) expects string, array\\<string, string\\|null\\>\\|string given\\.$#"
-			count: 4
-			path: src/SEOData.php
-
-		-
-			message: "#^Parameter \\#1 \\$suffix of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringEndsWith\\(\\) expects non\\-empty\\-string, string given\\.$#"
-			count: 1
-			path: src/TestSEO.php
+	ignoreErrors: []

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,17 +1,17 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Method Juampi92\\\\TestSEO\\\\SEOData\\:\\:charset\\(\\) should return string\\|null but returns array\\<string, string\\|null\\>\\|string\\|null\\.$#"
+			message: "#^Method Raiolanetworks\\\\PluginSEOTest\\\\SEOData\\:\\:charset\\(\\) should return string\\|null but returns array\\<string, string\\|null\\>\\|string\\|null\\.$#"
 			count: 1
 			path: src/SEOData.php
 
 		-
-			message: "#^Method Juampi92\\\\TestSEO\\\\SEOData\\:\\:description\\(\\) should return string\\|null but returns array\\<string, string\\|null\\>\\|string\\|null\\.$#"
+			message: "#^Method Raiolanetworks\\\\PluginSEOTest\\\\SEOData\\:\\:description\\(\\) should return string\\|null but returns array\\<string, string\\|null\\>\\|string\\|null\\.$#"
 			count: 1
 			path: src/SEOData.php
 
 		-
-			message: "#^Parameter \\#1 \\$content of class Juampi92\\\\TestSEO\\\\Tags\\\\Robots constructor expects string, array\\<string, string\\|null\\>\\|string given\\.$#"
+			message: "#^Parameter \\#1 \\$content of class Raiolanetworks\\\\PluginSEOTest\\\\Tags\\\\Robots constructor expects string, array\\<string, string\\|null\\>\\|string given\\.$#"
 			count: 1
 			path: src/SEOData.php
 
@@ -19,3 +19,8 @@ parameters:
 			message: "#^Parameter \\#1 \\$url of static method Spatie\\\\Url\\\\Url\\:\\:fromString\\(\\) expects string, array\\<string, string\\|null\\>\\|string given\\.$#"
 			count: 4
 			path: src/SEOData.php
+
+		-
+			message: "#^Parameter \\#1 \\$suffix of static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringEndsWith\\(\\) expects non\\-empty\\-string, string given\\.$#"
+			count: 1
+			path: src/TestSEO.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,5 +5,6 @@ parameters:
         - src
     level: 7
     #excludePaths:
-    checkMissingIterableValueType: false
     reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        - identifier: missingType.iterableValue

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
-  <coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.0/phpunit.xsd"
+         cacheDirectory=".phpunit.cache"
+>
+  <source>
     <include>
       <directory suffix=".php">src/</directory>
     </include>
-  </coverage>
+  </source>
   <testsuites>
-    <testsuite name="Permissions Test Suite">
+    <testsuite name="Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>
-  <php>
-    </php>
 </phpunit>

--- a/src/Parser/HTMLParser.php
+++ b/src/Parser/HTMLParser.php
@@ -23,7 +23,7 @@ class HTMLParser
     }
 
     /**
-     * @param  string|array<string>                   $attributes
+     * @param  string|array<string>  $attributes
      * @return string|array<string, string|null>|null
      */
     public function grabAttributeFrom(string $xpath, $attributes)
@@ -38,12 +38,12 @@ class HTMLParser
     }
 
     /**
-     * @param string|array<string>|null $attribute
+     * @param  string|array<string>|null  $attribute
      */
     public function grabMultiple(string $xpath, $attribute = null): array
     {
         $result = [];
-        $nodes  = $this->crawler->filterXPath($xpath);
+        $nodes = $this->crawler->filterXPath($xpath);
 
         foreach ($nodes as $node) {
             $result[] = $attribute !== null ? $this->getArgumentsFromNode($node, $attribute) : $node->textContent;
@@ -53,8 +53,8 @@ class HTMLParser
     }
 
     /**
-     * @param  DOMElement|DOMNode|null           $element
-     * @param  string|array<string>              $attributes
+     * @param  DOMElement|DOMNode|null  $element
+     * @param  string|array<string>  $attributes
      * @return string|array<string, string|null>
      */
     private function getArgumentsFromNode($element, $attributes)

--- a/src/Parser/HTMLParser.php
+++ b/src/Parser/HTMLParser.php
@@ -23,10 +23,12 @@ class HTMLParser
     }
 
     /**
-     * @param  string|array<string>  $attributes
-     * @return string|array<string, string|null>|null
+     * @template T of string|array<string>
+     *
+     * @param  T  $attributes
+     * @return (T is string ? string|null : array<string, string|null>|null)
      */
-    public function grabAttributeFrom(string $xpath, $attributes)
+    public function grabAttributeFrom(string $xpath, string|array $attributes)
     {
         $nodes = $this->crawler->filterXPath($xpath);
 
@@ -53,11 +55,12 @@ class HTMLParser
     }
 
     /**
-     * @param  DOMElement|DOMNode|null  $element
-     * @param  string|array<string>  $attributes
-     * @return string|array<string, string|null>
+     * @template T of string|array<string>
+     *
+     * @param  T  $attributes
+     * @return (T is string ? string : array<string, string|null>)
      */
-    private function getArgumentsFromNode($element, $attributes)
+    private function getArgumentsFromNode(DOMElement|DOMNode|null $element, string|array $attributes)
     {
         if (! $element || ! ($element instanceof DOMElement)) {
             return [];

--- a/src/SnapshotFormatters/SimpleSerializer.php
+++ b/src/SnapshotFormatters/SimpleSerializer.php
@@ -13,24 +13,24 @@ class SimpleSerializer implements SnapshotSerializer
     public function toArray(SEOData $data): array
     {
         return [
-            'title'          => $data->title(),
-            'description'    => $data->description(),
-            'robots'         => (string) $data->robots(),
-            'canonical'      => $this->formatUrl($data->canonical()),
-            'pagination'     => [
+            'title' => $data->title(),
+            'description' => $data->description(),
+            'robots' => (string) $data->robots(),
+            'canonical' => $this->formatUrl($data->canonical()),
+            'pagination' => [
                 'prev' => $this->formatUrl($data->prev()),
                 'next' => $this->formatUrl($data->next()),
             ],
             'relAltHreflang' => array_map(
                 fn (array $item) => [
                     'hreflang' => $item['hreflang'],
-                    'href'     => $this->formatUrl($item['href']),
+                    'href' => $this->formatUrl($item['href']),
                 ],
                 $data->alternateHrefLang()->jsonSerialize()
             ),
-            'h1'             => $data->h1s(),
-            'opengraph'      => $this->formatTagCollection($data->openGraph()),
-            'twitter'        => $this->formatTagCollection($data->twitter()),
+            'h1' => $data->h1s(),
+            'opengraph' => $this->formatTagCollection($data->openGraph()),
+            'twitter' => $this->formatTagCollection($data->twitter()),
         ];
     }
 

--- a/src/SnapshotFormatters/SimpleSerializer.php
+++ b/src/SnapshotFormatters/SimpleSerializer.php
@@ -6,6 +6,7 @@ namespace Raiolanetworks\PluginSEOTest\SnapshotFormatters;
 
 use Raiolanetworks\PluginSEOTest\SEOData;
 use Raiolanetworks\PluginSEOTest\Tags\TagCollection;
+use Stringable;
 
 class SimpleSerializer implements SnapshotSerializer
 {
@@ -61,12 +62,12 @@ class SimpleSerializer implements SnapshotSerializer
         return $this->formatUrl($url);
     }
 
-    protected function formatUrl(?string $url): ?string
+    protected function formatUrl(string|Stringable|null $url): ?string
     {
         if (! $url) {
             return null;
         }
 
-        return preg_replace('/\d+/', '{id}', $url);
+        return preg_replace('/\d+/', '{id}', (string) $url);
     }
 }

--- a/src/Support/ArrayPluck.php
+++ b/src/Support/ArrayPluck.php
@@ -7,7 +7,7 @@ namespace Raiolanetworks\PluginSEOTest\Support;
 class ArrayPluck
 {
     /**
-     * @param array<array<string, string>> $items
+     * @param  array<array<string, string>>  $items
      */
     public function __construct(private array $items) {}
 
@@ -16,12 +16,12 @@ class ArrayPluck
      */
     public function __invoke(string $key, string $value): array
     {
-        $array   = $this->items;
+        $array = $this->items;
         $results = [];
 
         foreach ($array as $item) {
             $itemValue = $item[$value];
-            $itemKey   = $item[$key];
+            $itemKey = $item[$key];
 
             if (! isset($results[$itemKey])) {
                 $results[$itemKey] = $itemValue;

--- a/src/Support/Memo.php
+++ b/src/Support/Memo.php
@@ -11,7 +11,7 @@ trait Memo
     /**
      * @template TValue
      *
-     * @param  callable(): TValue $value
+     * @param  callable(): TValue  $value
      * @return TValue
      */
     protected function memo(string $key, callable $value): mixed

--- a/src/Tags/TagCollection.php
+++ b/src/Tags/TagCollection.php
@@ -18,7 +18,7 @@ class TagCollection
     public function get(string $property)
     {
         // Normalize property
-        $property = $this->prefix . ltrim($property, $this->prefix);
+        $property = $this->prefix.ltrim($property, $this->prefix);
 
         return $this->metadata[$property] ?? null;
     }

--- a/src/TestSEO.php
+++ b/src/TestSEO.php
@@ -87,6 +87,9 @@ class TestSEO implements JsonSerializable
         return $this;
     }
 
+    /**
+     * @param  non-empty-string  $expected
+     */
     public function assertTitleEndsWith(string $expected): self
     {
         Assert::assertStringEndsWith($expected, $this->data->title());

--- a/src/TestSEO.php
+++ b/src/TestSEO.php
@@ -18,8 +18,8 @@ class TestSEO implements JsonSerializable
 
     public function __construct(string $content, ?SnapshotSerializer $snapshotSerializer = null)
     {
-        $html                     = new HTMLParser($content);
-        $this->data               = new SEOData($html);
+        $html = new HTMLParser($content);
+        $this->data = new SEOData($html);
         $this->snapshotSerializer = $snapshotSerializer ?? new SimpleSerializer;
     }
 
@@ -52,8 +52,8 @@ class TestSEO implements JsonSerializable
     {
         $robots = $this->data->robots();
 
-        Assert::assertTrue($robots->noindex(), 'Robots should be noindex and nofollow, but found: ' . (string) $robots);
-        Assert::assertTrue($robots->nofollow(), 'Robots should be noindex and nofollow, but found: ' . (string) $robots);
+        Assert::assertTrue($robots->noindex(), 'Robots should be noindex and nofollow, but found: '.(string) $robots);
+        Assert::assertTrue($robots->nofollow(), 'Robots should be noindex and nofollow, but found: '.(string) $robots);
 
         return $this;
     }

--- a/tests/ArrayPluckTest.php
+++ b/tests/ArrayPluckTest.php
@@ -4,14 +4,13 @@ declare(strict_types=1);
 
 namespace Raiolanetworks\PluginSEOTest\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Raiolanetworks\PluginSEOTest\Support\ArrayPluck;
 
 class ArrayPluckTest extends TestCase
 {
-    /**
-     * @dataProvider pluckDataProvider
-     */
+    #[DataProvider('pluckDataProvider')]
     public function test_should_pluck_array(array $expected, array $items, string $key, string $value): void
     {
         $this->assertEqualsCanonicalizing(

--- a/tests/ArrayPluckTest.php
+++ b/tests/ArrayPluckTest.php
@@ -23,21 +23,21 @@ class ArrayPluckTest extends TestCase
     public static function pluckDataProvider(): array
     {
         return [
-            'It plucks the values'                                       => [
+            'It plucks the values' => [
                 'expected' => ['foo' => 'bar', 'foo2' => 'bar2'],
-                'items'    => [['name' => 'foo', 'content' => 'bar'], ['name' => 'foo2', 'content' => 'bar2']],
-                'key'      => 'name',
-                'value'    => 'content',
+                'items' => [['name' => 'foo', 'content' => 'bar'], ['name' => 'foo2', 'content' => 'bar2']],
+                'key' => 'name',
+                'value' => 'content',
             ],
             'It groups results into an array when the keys are the same' => [
                 'expected' => ['foo' => ['bar', 'bar2'], 'foo2' => 'bar3'],
-                'items'    => [
+                'items' => [
                     ['property' => 'foo', 'content' => 'bar'],
                     ['property' => 'foo', 'content' => 'bar2'],
                     ['property' => 'foo2', 'content' => 'bar3'],
                 ],
-                'key'      => 'property',
-                'value'    => 'content',
+                'key' => 'property',
+                'value' => 'content',
             ],
         ];
     }

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Raiolanetworks\PluginSEOTest\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\ExpectationFailedException;
 use PHPUnit\Framework\TestCase;
 use Raiolanetworks\PluginSEOTest\TestSEO;
@@ -36,9 +37,7 @@ class AssertionsTest extends TestCase
         $this->assertEquals('https://testpage.com/es/product/44/reviews?page=2', $testSeo->data->alternateHrefLang()->get('es'));
     }
 
-    /**
-     * @dataProvider breakAssertionsCase2DataProvider
-     */
+    #[DataProvider('breakAssertionsCase2DataProvider')]
     public function test_should_break_on_assertions_case_2(callable $evaluation): void
     {
         $this->expectException(ExpectationFailedException::class);
@@ -81,9 +80,7 @@ class AssertionsTest extends TestCase
             ->assertAlternateHrefLangIsEmpty();
     }
 
-    /**
-     * @dataProvider breakAssertionsCase3DataProvider
-     */
+    #[DataProvider('breakAssertionsCase3DataProvider')]
     public function test_should_break_on_assertions_case_3(callable $evaluation): void
     {
         $this->expectException(ExpectationFailedException::class);

--- a/tests/AssertionsTest.php
+++ b/tests/AssertionsTest.php
@@ -13,7 +13,7 @@ class AssertionsTest extends TestCase
     public function test_should_pass_assertions(): void
     {
         // Arrange
-        $page = file_get_contents(__DIR__ . '/stubs/test-case-2.html');
+        $page = file_get_contents(__DIR__.'/stubs/test-case-2.html');
 
         // Act
         $testSeo = new TestSEO($page);
@@ -44,7 +44,7 @@ class AssertionsTest extends TestCase
         $this->expectException(ExpectationFailedException::class);
 
         // Arrange
-        $page = file_get_contents(__DIR__ . '/stubs/test-case-2.html');
+        $page = file_get_contents(__DIR__.'/stubs/test-case-2.html');
 
         // Act
         $testSeo = new TestSEO($page);
@@ -56,11 +56,11 @@ class AssertionsTest extends TestCase
     public static function breakAssertionsCase2DataProvider(): array
     {
         return [
-            'Empty canonical'         => [fn (TestSEO $testSEO) => $testSEO->assertCanonicalIsEmpty()],
-            'Wrong canonical'         => [fn (TestSEO $testSEO) => $testSEO->assertCanonicalIs('https://testpage.com/en/product/44?asd=1')],
-            'Empty Pagination'        => [fn (TestSEO $testSEO) => $testSEO->assertPaginationIsEmpty()],
-            'Empty Robots'            => [fn (TestSEO $testSEO) => $testSEO->assertRobotsIsEmpty()],
-            'Wrong Title'             => [fn (TestSEO $testSEO) => $testSEO->assertTitleIs('This is my test title')],
+            'Empty canonical' => [fn (TestSEO $testSEO) => $testSEO->assertCanonicalIsEmpty()],
+            'Wrong canonical' => [fn (TestSEO $testSEO) => $testSEO->assertCanonicalIs('https://testpage.com/en/product/44?asd=1')],
+            'Empty Pagination' => [fn (TestSEO $testSEO) => $testSEO->assertPaginationIsEmpty()],
+            'Empty Robots' => [fn (TestSEO $testSEO) => $testSEO->assertRobotsIsEmpty()],
+            'Wrong Title' => [fn (TestSEO $testSEO) => $testSEO->assertTitleIs('This is my test title')],
             'Empty AlternateHreflang' => [fn (TestSEO $testSEO) => $testSEO->assertAlternateHrefLangIsEmpty()],
         ];
     }
@@ -68,7 +68,7 @@ class AssertionsTest extends TestCase
     public function test_should_pass_assertions_on_empty_case_3(): void
     {
         // Arrange
-        $page = file_get_contents(__DIR__ . '/stubs/test-case-3.html');
+        $page = file_get_contents(__DIR__.'/stubs/test-case-3.html');
 
         // Act
         $testSeo = new TestSEO($page);
@@ -89,7 +89,7 @@ class AssertionsTest extends TestCase
         $this->expectException(ExpectationFailedException::class);
 
         // Arrange
-        $page = file_get_contents(__DIR__ . '/stubs/test-case-3.html');
+        $page = file_get_contents(__DIR__.'/stubs/test-case-3.html');
 
         // Act
         $testSeo = new TestSEO($page);
@@ -101,7 +101,7 @@ class AssertionsTest extends TestCase
     public static function breakAssertionsCase3DataProvider(): array
     {
         return [
-            'More than one h1'       => [fn (TestSEO $testSEO) => $testSEO->assertThereIsOnlyOneH1()],
+            'More than one h1' => [fn (TestSEO $testSEO) => $testSEO->assertThereIsOnlyOneH1()],
             'Has images with no alt' => [fn (TestSEO $testSEO) => $testSEO->assertAllImagesHaveAltText()],
         ];
     }

--- a/tests/SEODataTest.php
+++ b/tests/SEODataTest.php
@@ -23,7 +23,7 @@ EMPTY_HTML;
 
         // Act
         $parser = new HTMLParser($page);
-        $seo    = new SEOData($parser);
+        $seo = new SEOData($parser);
 
         // Assert
         $this->assertNull($seo->title());
@@ -45,11 +45,11 @@ EMPTY_HTML;
     public function test_it_parses_html_into_instance(): void
     {
         // Arrange
-        $page = file_get_contents(__DIR__ . '/stubs/test.html');
+        $page = file_get_contents(__DIR__.'/stubs/test.html');
 
         // Act
         $parser = new HTMLParser($page);
-        $seo    = new SEOData($parser);
+        $seo = new SEOData($parser);
 
         // Assert
         $this->assertEquals('This is my test title.', $seo->title());

--- a/tests/SnapshotTest.php
+++ b/tests/SnapshotTest.php
@@ -12,27 +12,27 @@ class SnapshotTest extends TestCase
     public function test_should_create_the_snapshot(): void
     {
         // Arrange
-        $page = file_get_contents(__DIR__ . '/stubs/test-case-2.html');
+        $page = file_get_contents(__DIR__.'/stubs/test-case-2.html');
 
         // Act
-        $testSeo  = new TestSEO($page);
+        $testSeo = new TestSEO($page);
         $snapshot = json_decode(json_encode($testSeo), true);
 
         // Assert
         $this->assertEquals([
-            'title'          => 'Reviews for product #44 - My Web',
-            'canonical'      => 'https://testpage.com/en/product/{id}/reviews',
-            'description'    => 'The product 44 is amazing.',
-            'twitter'        => [
-                'twitter:card'  => 'TwitterFooBar #44',
+            'title' => 'Reviews for product #44 - My Web',
+            'canonical' => 'https://testpage.com/en/product/{id}/reviews',
+            'description' => 'The product 44 is amazing.',
+            'twitter' => [
+                'twitter:card' => 'TwitterFooBar #44',
                 'twitter:image' => 'https://testpage.com/images/products/{id}.jpg',
             ],
-            'opengraph'      => [
+            'opengraph' => [
                 'og:site_name' => 'OGFooBar',
-                'og:image'     => 'https://testpage.com/images/products/{id}.jpg',
+                'og:image' => 'https://testpage.com/images/products/{id}.jpg',
             ],
-            'robots'         => 'nofollow, noindex',
-            'pagination'     => [
+            'robots' => 'nofollow, noindex',
+            'pagination' => [
                 'prev' => 'https://testpage.com/en/product/{id}/reviews?page={id}',
                 'next' => 'https://testpage.com/en/product/{id}/reviews?page={id}',
             ],
@@ -40,43 +40,43 @@ class SnapshotTest extends TestCase
                 ['hreflang' => 'es', 'href' => 'https://testpage.com/es/product/{id}/reviews?page={id}'],
                 ['hreflang' => 'pt', 'href' => 'https://testpage.com/pt/product/{id}/reviews?page={id}'],
             ],
-            'h1'             => ['Product #44'],
+            'h1' => ['Product #44'],
         ], $snapshot);
     }
 
     public function test_should_create_the_snapshot_on_empty_data(): void
     {
         // Arrange
-        $page = file_get_contents(__DIR__ . '/stubs/test-case-3.html');
+        $page = file_get_contents(__DIR__.'/stubs/test-case-3.html');
 
         // Act
-        $testSeo  = new TestSEO($page);
+        $testSeo = new TestSEO($page);
         $snapshot = json_decode(json_encode($testSeo), true);
 
         // Assert
         $this->assertEquals([
-            'title'          => 'Update product #44 - My Web',
-            'canonical'      => null,
-            'description'    => 'The product 44 is amazing.',
-            'twitter'        => null,
-            'opengraph'      => null,
-            'robots'         => '',
-            'pagination'     => [
+            'title' => 'Update product #44 - My Web',
+            'canonical' => null,
+            'description' => 'The product 44 is amazing.',
+            'twitter' => null,
+            'opengraph' => null,
+            'robots' => '',
+            'pagination' => [
                 'prev' => null,
                 'next' => null,
             ],
             'relAltHreflang' => [],
-            'h1'             => ['Update Product #44', 'Second h1. This must be bad.'],
+            'h1' => ['Update Product #44', 'Second h1. This must be bad.'],
         ], $snapshot);
     }
 
     public function test_should_create_the_tag_collection_snapshot_on_array_values(): void
     {
         // Arrange
-        $page = file_get_contents(__DIR__ . '/stubs/test-case-4.html');
+        $page = file_get_contents(__DIR__.'/stubs/test-case-4.html');
 
         // Act
-        $testSeo  = new TestSEO($page);
+        $testSeo = new TestSEO($page);
         $snapshot = json_decode(json_encode($testSeo), true);
 
         // Assert

--- a/tests/Tags/TagCollectionTest.php
+++ b/tests/Tags/TagCollectionTest.php
@@ -60,7 +60,7 @@ class TagCollectionTest extends TestCase
 
         // Assert
         $this->assertEquals([
-            'twitter:url'   => 'https://image.url/',
+            'twitter:url' => 'https://image.url/',
             'twitter:image' => [
                 'https://image.url/here-1.jpg',
                 'https://image.url/here-2.jpg',


### PR DESCRIPTION
## Summary

### Dependencies updated
- **PHP**: `^8.0.2` → `^8.2` (drop PHP 8.0 and 8.1, both EOL)
- **illuminate/macroable**: `^7.0|...|^11.0` → `^11.0|^12.0` (drop Laravel 7–10, all EOL)
- **phpunit/phpunit**: `^8.3|^9.0|^10.0` → `^10.0|^11.0`
- **spatie/url**: `^1.3.4|^2.0` → `^2.0`
- **symfony/dom-crawler**: `^5.4|^6.1` → `^6.1|^7.0`
- **laravel/pint** (dev): `^1.0` → `^1.18`

### Bug fixes
- Fix `SimpleSerializer::formatUrl()` TypeError: accept `string|Stringable|null` to handle `Spatie\Url\Url` objects
- Fix PHPStan baseline using old `Juampi92\TestSEO` namespace

### Code quality
- Add conditional return types to `HTMLParser::grabAttributeFrom()` and `getArgumentsFromNode()`, eliminating all PHPStan baseline suppressions
- Type `assertTitleEndsWith` param as `non-empty-string`
- Replace `@dataProvider` doc-comments with PHP 8 attributes
- Replace deprecated `checkMissingIterableValueType` PHPStan config with `ignoreErrors` identifier
- Update `phpunit.xml.dist` to PHPUnit 11 schema, remove deprecated attributes

### CI/CD
- Test matrix: PHP 8.2, 8.3, 8.4 × PHPUnit 10, 11
- Bump `actions/checkout` v3 → v4
- Bump `ramsey/composer-install` v1 → v2
- Bump `laravel-pint-action` 1.0.0 → 2.5
- Bump `git-auto-commit-action` v4 → v5
- Add `contents: write` permission to pint workflow

## Test plan

- [x] CI passes on PHP 8.2, 8.3 and 8.4
- [x] PHPUnit 10 and 11 both green
- [x] PHPStan passes with empty baseline
- [x] Pint code style passes
- [x] Zero PHPUnit deprecations