### PR TITLE
Add Laravel 13 support and migrate to PHPStan 2

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -14,8 +14,12 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3, 8.4]
-        phpunit: [10.*, 11.*]
+        phpunit: [10.*, 11.*, 12.*]
         stability: [prefer-lowest, prefer-stable]
+        exclude:
+          # PHPUnit 12 requires PHP 8.3+
+          - php: 8.2
+            phpunit: 12.*
 
     name: P${{ matrix.php }} - PHPUnit ${{ matrix.phpunit }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Test meta tags, titles, canonical URLs, Open Graph, Twitter Cards, robots direct
 
 ## Requirements
 
-- PHP 8.2+
-- Laravel 11 or 12
-- PHPUnit 10 or 11
+- PHP 8.2+ (8.3+ required when used with Laravel 13)
+- Laravel 11, 12, or 13
+- PHPUnit 10, 11, or 12
 
 ## Table of Contents
 

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,14 @@
     ],
     "require": {
         "php": "^8.2",
-        "illuminate/macroable": "^11.0|^12.0",
-        "phpunit/phpunit": "^10.0|^11.0",
+        "illuminate/macroable": "^11.0|^12.0|^13.0",
+        "phpunit/phpunit": "^10.0|^11.0|^12.0",
         "spatie/url": "^2.0",
         "symfony/dom-crawler": "^6.1|^7.0"
     },
     "require-dev": {
         "laravel/pint": "^1.18",
-        "phpstan/phpstan": "^1.8"
+        "phpstan/phpstan": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Parser/HTMLParser.php
+++ b/src/Parser/HTMLParser.php
@@ -39,13 +39,16 @@ class HTMLParser
         return $this->getArgumentsFromNode($nodes->getNode(0), $attributes);
     }
 
+    /**
+     * @param  string|array<string>|null  $attribute
+     */
     public function grabMultiple(string $xpath, string|array|null $attribute = null): array
     {
         $result = [];
         $nodes = $this->crawler->filterXPath($xpath);
 
         foreach ($nodes as $node) {
-            $result[] = $attribute !== null ? $this->getArgumentsFromNode($node, $attribute) : $node->textContent; // @phpstan-ignore argument.templateType
+            $result[] = $attribute !== null ? $this->getArgumentsFromNode($node, $attribute) : $node->textContent;
         }
 
         return $result;

--- a/src/Tags/Robots.php
+++ b/src/Tags/Robots.php
@@ -27,13 +27,13 @@ class Robots implements JsonSerializable, Stringable
 
     public const NO_SNIPPET = 'nosnippet';
 
-    /** @var array<Robots::*> */
+    /** @var array<int, string> */
     private array $parameters;
 
     public function __construct(
         string $content
     ) {
-        /** @var array<Robots::*> */
+        /** @var list<string> $parameters */
         $parameters = array_map(
             'trim',
             explode(',', $content)


### PR DESCRIPTION
## Summary

Adds Laravel 13 compatibility, ensures the package works on PHP 8.3 and 8.4, and migrates static analysis to PHPStan 2.

## Dependencies (`composer.json`)

- `illuminate/macroable`: `^11.0|^12.0` → `^11.0|^12.0|^13.0` (Laravel 13)
- `phpunit/phpunit`: `^10.0|^11.0` → `^10.0|^11.0|^12.0` (Laravel 13 projects commonly use PHPUnit 12)
- `phpstan/phpstan`: `^1.8` → `^2.0`
- `php` kept at `^8.2`; `symfony/dom-crawler` kept at `^6.1|^7.0`

## CI

- Added `12.*` to the PHPUnit matrix in `run-tests.yml`, excluding `PHP 8.2 + PHPUnit 12` (PHPUnit 12 requires PHP ≥ 8.3).

## PHPStan 2 migration

Fixed the two stricter findings in code (no baseline added):
- **`Robots.php`** — the `array<Robots::*>` PHPDoc claimed no falsy values, flagging `array_filter` as a no-op. The real type from `explode()` is `array<string>` (empty strings the filter legitimately removes).
- **`HTMLParser.php`** — removed a now-unnecessary `@phpstan-ignore`; tightening the param PHPDoc to `string|array<string>|null` lets the template resolve cleanly.

## Decisions

- **PHP min stays `^8.2`**: the package only depends on `illuminate/macroable` (not the full framework), so it keeps Laravel 11/12 + PHP 8.2 compatibility. Laravel 13 already enforces PHP 8.3 via its own constraint.
- **`symfony/dom-crawler` not bumped to `^8.0`**: v8 is beta and requires PHP ≥ 8.4.1, which would break PHP 8.3. `^7.0` already works with Laravel 13.
- **Larastan not added**: the code uses no Laravel-specific features (Eloquent, facades, container) — only DomCrawler and the `Macroable` trait — so it would add no value while pulling in heavy dependencies.

## Verification

Locally on PHP 8.3: PHPStan 2 reports no errors, Pint passes, and all 32 tests (118 assertions) pass against `illuminate/macroable` v13 + PHPUnit 12.